### PR TITLE
DateService RFC - Very much WIP!

### DIFF
--- a/packages/interfaces/src/service/date-service.interface.ts
+++ b/packages/interfaces/src/service/date-service.interface.ts
@@ -1,0 +1,22 @@
+/**
+ * Date service for parsing and formatting dates
+ */
+export interface DateService {
+    /**
+     * Parses a date string and returns a Date object.
+     *
+     * @param {string} input - A string to parse.
+     * @param {string} format - The format of the string to parse, optional if the link is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+     * @returns {Date}
+     */
+    parse(input: string, format?: string): Date;
+
+    /**
+     * Formats a Date object and returns a string on the requested format.
+     *
+     * @param {Date} date - The date to format.
+     * @param {string} format - The wanted format.
+     * @returns {string}
+     */
+    format(date: Date, format: string): string;
+}


### PR DESCRIPTION
A place to discuss and work out an interface for a DateService that can be used to unify parsing and formatting of dates within each client, and the interface for doing so between clients.

<details>
<summary>Originating discussion (from Teams, then Slack)</summary>

@anderssonjohan
> To answer some obvious questions... YES! We're using dayjs and not moment 🙂

@jensgustafsson
> We're using date-fns in lime-crm-components

@anderssonjohan
> Oh! We noticed daysjs being used in lime-elements and thought that was the preferred lib over momentjs.

@jensgustafsson
> It might be! 🙂 Not sure which one that is the best 😛

@adrianschmidt
> dayjs is built to be as close to a drop-in replacement for momentjs as possible, if I recall correctly. And since we've been using momentjs a lot, dayjs seems like a reasonable default choice I think… but perhaps there are better reasons to go for something else?
We've been discussing having some kind of date-formatter, either in lime-elements or perhaps in lime-web-components…
>
> Adding a formatter service interface to lime-web-components would hopefully eliminate the need for depending on a date-lib for the vast majority of add-ons…

@anderssonjohan
> Since we have a subset of the date and time domain represented by specific types (quarter, week, date, datetime etc) isolated by components I think it should be reasonable to have utils exposed from lime-elements that doesn’t expose the lib we use.
>
> It would also be nice to have utils for `fromNow` etc (“now”, “2 minutes ago” with localization).
>
> It would then make sense to use it with the date-picker samples and their results printer (which I recall you added for some event recorder/list?).

@adrianschmidt
> This one you mean?
https://github.com/Lundalogik/lime-elements/blob/main/src/examples/example-event-printer.tsx
> ![image](https://user-images.githubusercontent.com/154725/117154892-98909080-adbc-11eb-8b4a-00cc7c616895.png)

@anderssonjohan
> ✅ 👌

@adrianschmidt
> I think there's some discussion to be had about what should potentially be in lime-elements and what should potentially be an interface in lime-web-components. Putting things in lime-elements would make lime-elements decide the formats. So, for example, if the consumer requests a date formatted as "long time" (`LT` in moment, which I think is a useful abstraction), lime-elements would decide whether that means `2021-05-04 10:56` or `2021 May 4, 10:56` for example. Using the same locale, the result would always be the same regardless of which client we're in.
>
> If we instead made it an interface in lime-web-components, then each client would be responsible for supplying an implementation, and the CRM web client could return one format for "LT", while the desktop client could return a different format…
>
> There are pros and cons for both, and some things might be considered either a pro or a con depending on who you'd ask :smile:

@anderssonjohan
> When working with BatmanJS (old thing) I really liked the way you could use small util filters like “pluralize” http://batmanjs.org/docs/api/batman.view_filters.html#pluralize(value%2C_count)_%3A_string A nice thing would be to have a single import where you can add (alt-enter in VSCode :joy: ) the formatting utils of your need. Something like:
> `import { dateQuarter, fromNow, ……. } from '@limetech/formatting`
> and then
> `<my-comp prop={dateQuarter(this.selectedDate)}/>`
>
> In Lime Field we also do localization from UTC in these parts. All data from the API is UTC there and all localization is made as close to “the user”/rendering at all times. If we talk the desktop WPF client it’s the same with data bindings where such formatter util like the example above is a valueconverter passed to the binding expression.
What I’m NOT asking for here is something like this util in terraform https://www.terraform.io/docs/language/functions/formatdate.html It should be short and simple and I should be able to use `prop={fromNow(this.dateOrStr)}` for both JSON data (date as string) and JS date objects.
>
>…and import { defaultLocale, localLocale } … with defaultLocale('sv') for global override and
>```
>render() {
>  return [
>    localLocale('sv', () => [<limel-date-picker selectedDate={this.date}/>, <span>{fromNow(this.date)}</span>]),
>    localLocale('fi', () => (<p>In Finland the date looks like this: {fromNow(this.date)}</p>))
>  ];
>}
>```
>Just braindumping.. :joy:

@pontusn
> Interesting... How about unified parsing and validation?

@adrianschmidt
> Not sure what you mean… can you elaborate?

@pontusn 
> Parsing and validating localized data formats (ie. date, number, currency etc.) is error prune, primarily for data entry via the user interface, but also for import and integrations.
>
> From my perspective a unified common service/api/helper for this is way better than each component implementing or using their own library.
>
> Keeping formatting, validation and parsing together makes sense to avoid issues where values formatted for display cannot be parsed back.

@adrianschmidt 
> > a unified common service/api/helper for this is way better than each component implementing or using their own library
> Yes, I agree, that's kind of the foundation for the discussion, I feel…? :slightly_smiling_face:
>
> Thinking a little more about it, while your comment could be taken as an argument for putting the parsing and formatting logic in lime-elements, the problem with that is that, presumably, the desktop client won't be able to run all its date parsing and formatting through a service from lime-elements. Which then instead means that if "centralising" to lime-elements, we in effect force the desktop client to de-centralise, since all web component add-ons will be using the formatting and parsing from lime-elements, while the rest of the client will be using something else. (The same argument of course applies for implementing the service in lime-web-components.)
>
> But, if we instead put an interface for the service in lime-web-components, and have each client supply the implementation of that service, each client can make sure that all date processing within the client is done by the same underlying implementation. Then there's of course nothing stopping us from doing what we can to unify the handling between clients too. The CRM web client and Lime Go could for example share a common javascript implementation, or the CRM web client could pass off date processing to a python service run on the backend, which is the same service used by the desktop client (we probably don't want to have to send a request to the server just to parse or format a date, but I'm just giving examples here).
>
> Thoughts?

@pontusn
> Agree 100%...

@anderssonjohan
> Sounds fair, but I think I need draft spec on the service interface to come up with more/better feedback
</details>

The first draft added at the point this PR was opened obviously needs a lot more work. This is just so that we have somewhere to continue the discussion, and to collect any work done.