### PR TITLE
Added length as optional property on interface Property

### DIFF
--- a/packages/interfaces/src/limetype.interface.ts
+++ b/packages/interfaces/src/limetype.interface.ts
@@ -35,6 +35,7 @@ export interface Property {
     fieldorder: number;
     has_sql?: boolean; // eslint-disable-line camelcase
     label: string;
+    length?: number;
     localname: string;
     name: string;
     required: boolean;


### PR DESCRIPTION
The `length` property is the maximum number of characters allowed in a string property i.e. `text` `string` `phone` `link` e.t.c.